### PR TITLE
fix(release): 上传原生 CLI 二进制到 GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,4 +128,5 @@ jobs:
           files: |
             release-artifacts/*.tar.gz
             release-artifacts/*.sha256
+            release-artifacts/source-map-parser-*
           generate_release_notes: true


### PR DESCRIPTION
release job 的 files glob 只挑了 *.tar.gz 和 *.sha256，裸二进制
source-map-parser-<platform>-<arch>（无后缀 / .exe）没被任何 glob 命中，
导致 v0.6.0 只发出了校验和、三平台二进制全部 404。补一行 glob 修复。
